### PR TITLE
Arrumado: Zoom sempre sendo feito a uma nova rederização

### DIFF
--- a/src/components/Map/MapComponent.tsx
+++ b/src/components/Map/MapComponent.tsx
@@ -14,6 +14,7 @@ interface MapComponentProps {
     onMarkerClick: (item: Denuncia | Acao) => void;
     onSelectionClick: (id: number, status: StatusModel) => void;
     detailViewItem: Denuncia | Acao | null;
+    setDetailViewItem: (item: Denuncia | Acao | null) => void
 }
 
 export function MapComponent({
@@ -23,14 +24,18 @@ export function MapComponent({
     denunciasSelecionadas,
     onMarkerClick,
     onSelectionClick,
-    detailViewItem
+    detailViewItem,
+    setDetailViewItem
 }: MapComponentProps) {
-    
+
     const MapViewUpdater: FC<{ item: Denuncia | Acao | null }> = ({ item }) => {
         const map = useMap();
         useEffect(() => {
             if (item) {
-                map.flyTo([item.lat, item.lon], 16);
+                map.flyTo([item.lat, item.lon], 16)
+                map.on("moveend", () => {
+                    setDetailViewItem(null)
+                })
             }
         }, [item, map]);
         return null;

--- a/src/pages/OcorrenciasPage.tsx
+++ b/src/pages/OcorrenciasPage.tsx
@@ -8,7 +8,7 @@ import { useOcorrencias } from "../hooks/useOcorrencias";
 import { MapFilters } from "../components/Map/MapFilters";
 
 export function OcorrenciasPage() {
-    const { denuncias, acoes, criarNovaAcao, filteredData, setFilter } = useOcorrencias();
+    const { denuncias, acoes, criarNovaAcao, filteredData, setFilter } = useOcorrencias();    
 
     const [modoSelecao, setModoSelecao] = useState<boolean>(false);
     const [denunciasSelecionadas, setDenunciasSelecionadas] = useState<number[]>([]);
@@ -17,7 +17,7 @@ export function OcorrenciasPage() {
 
     const handleSelectionClick = (id: number) => {
         if (modoSelecao) {
-        setDenunciasSelecionadas(prev => prev.includes(id) ? prev.filter(item => item !== id) : [...prev, id]);
+            setDenunciasSelecionadas(prev => prev.includes(id) ? prev.filter(item => item !== id) : [...prev, id]);
         }
     };
     
@@ -54,6 +54,7 @@ export function OcorrenciasPage() {
                 onMarkerClick={handleItemClick}
                 onSelectionClick={handleSelectionClick}
                 detailViewItem={detailViewItem}
+                setDetailViewItem={setDetailViewItem}
             />
         </main>
         <CreateActionModal isOpen={isCreateModalOpen} onClose={() => setCreateModalOpen(false)} onSubmit={handleFinalizarCriacaoAcao} selectionCount={denunciasSelecionadas.length}/>


### PR DESCRIPTION
Agora após realizar o zoom automaticamente o estado de visualização é limpo evitando que após o componente seja renderizado novamente na tela ele aplique o zoom sem de fato o usuário ter clicado no pino desejado